### PR TITLE
MeasurementsService and client refactor

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,7 +174,7 @@ func checkError(resp *http.Response) error {
 	if resp.StatusCode >= 299 {
 		dec := json.NewDecoder(resp.Body)
 		dec.Decode(&errResponse)
-		log.Printf("Error: %+v\n", errResponse)
+		log.Printf("error: %+v\n", errResponse)
 		return &errResponse
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -4,44 +4,81 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"net/url"
 	"regexp"
+
+	"fmt"
+
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"fmt"
 )
 
-const(
+const (
 	MajorVersion = 0
 	MinorVersion = 1
 	PatchVersion = 0
+
+	// MeasurementPostMaxBatchSize defines the max number of Measurements to send to the API at once
+	MeasurementPostMaxBatchSize = 1000
+	defaultBaseURL              = "https://api.appoptics.com/v1/"
+	defaultMediaType            = "application/json"
 )
 
 var (
-	// Version is the current version of this client
+	// Version is the current version of this httpClient
 	Version = fmt.Sprintf("%d.%d.%d", MajorVersion, MinorVersion, PatchVersion)
 
 	regexpIllegalNameChars = regexp.MustCompile("[^A-Za-z0-9.:_-]") // from https://www.AppOptics.com/docs/api/#measurements
 	ErrBadStatus           = errors.New("Received non-OK status from AppOptics POST")
 )
 
-type Client interface {
-	Post(batch *MeasurementsBatch) error
+// ServiceAccessor defines an interface for talking to  via domain-specific service constructs
+type ServiceAccessor interface {
+	// MeasurementsService implements an interface for dealing with  Measurements
+	MeasurementsService() MeasurementsCommunicator
+	// SpacesService implements an interface for dealing with  Spaces
+	SpacesService() SpacesCommunicator
 }
 
-type SimpleClient struct {
+// ErrorResponse represents the response body returned when the API reports an error
+type ErrorResponse struct {
+	// Errors holds the error information from the API
+	Errors interface{} `json:"errors"`
+}
+
+// TODO: add API reference URLs here
+// RequestErrorMessage represents the error schema for request errors
+type RequestErrorMessage map[string][]string
+
+// TODO: add API reference URLs here
+// ParamErrorMessage represents the error schema for param errors
+type ParamErrorMessage []map[string]string
+
+// Client implements ServiceAccessor
+type Client struct {
+	// baseURL is the base endpoint of the remote  service
+	baseURL *url.URL
+	// httpClient is the http.Client singleton used for wire interaction
 	httpClient *http.Client
-	URL        string
-	Token      string
+	// token is the private part of the API credential pair
+	token string
+	// measurementsService embeds the httpClient and implements access to the Measurements API
+	measurementsService MeasurementsCommunicator
+	// spacesService embeds the httpClient and implements access to the Spaces API
+	spacesService SpacesCommunicator
 }
 
-func NewClient(url, token string) Client {
-	return &SimpleClient{
-		URL:   url,
-		Token: token,
+// TODO: make this take an optional URL parameter so it can be used against Librato API
+func NewClient(token string) *Client {
+	baseURL, _ := url.Parse(defaultBaseURL)
+	c := &Client{
+		token:   token,
+		baseURL: baseURL,
 		httpClient: &http.Client{
+
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				MaxIdleConnsPerHost: 4,
@@ -49,71 +86,104 @@ func NewClient(url, token string) Client {
 			},
 		},
 	}
+	c.measurementsService = &MeasurementsService{c}
+	c.spacesService = &SpacesService{c}
+
+	return c
 }
 
-type MeasurementsBatch struct {
-	Time         int64             `json:"time"`
-	Period       int64             `json:"period,omitempty"`
-	Tags         map[string]string `json:"tags,omitempty"`
-	Measurements []Measurement     `json:"measurements,omitempty"`
-}
-
-type Measurement struct {
-	Name       string                 `json:"name"`
-	Tags       map[string]string      `json:"tags,omitempty"`
-	Value      interface{}            `json:"value,omitempty"`
-	Count      interface{}            `json:"count,omitempty"`
-	Sum        interface{}            `json:"sum,omitempty"`
-	Min        interface{}            `json:"min,omitempty"`
-	Max        interface{}            `json:"max,omitempty"`
-	Last       interface{}            `json:"last,omitempty"`
-	Attributes map[string]interface{} `json:"attributes,omitempty"`
-}
-
-// Used for the collector's internal metrics
-func (c *SimpleClient) Post(batch *MeasurementsBatch) error {
-	if c.Token == "" {
-		return errors.New("AppOptics client not authenticated")
-	}
-	return c.post(batch, c.Token)
-}
-
-func (c *SimpleClient) post(batch *MeasurementsBatch, token string) error {
-	json, err := json.Marshal(batch)
+// NewRequest standardizes the request being sent
+func (c *Client) NewRequest(method, path string, body interface{}) (*http.Request, error) {
+	rel, err := url.Parse(path)
 	if err != nil {
-		log.Error("Error marshaling AppOptics measurements", "err", err)
-		return err
+		return nil, err
 	}
 
-	log.Debug("POSTing measurements to AppOptics", "body", string(json))
-	req, err := http.NewRequest("POST", c.URL, bytes.NewBuffer(json))
-	if err != nil {
-		log.Error("Error POSTing measurements to AppOptics", "err", err)
-		return err
-	}
+	requestURL := c.baseURL.ResolveReference(rel)
 
-	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(token, "")
+	var buffer io.ReadWriter
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		log.Error("Error reading response to AppOptics measurements request", "err", err)
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Error("Error reading response body from AppOptics", "statusCode", resp.StatusCode, "err", err)
-			return err
+	if body != nil {
+		buffer = &bytes.Buffer{}
+		encodeErr := json.NewEncoder(buffer).Encode(body)
+		if encodeErr != nil {
+			dumpMeasurements(body)
+			return nil, encodeErr
 		}
 
-		log.Error("Error POSTing measurements to AppOptics", "statusCode", resp.StatusCode, "respBody", string(body))
-		return ErrBadStatus
+	}
+	req, err := http.NewRequest(method, requestURL.String(), buffer)
+
+	if err != nil {
+		return nil, err
 	}
 
-	log.Debug("Finished uploading AppOptics measurements")
+	req.SetBasicAuth("token", c.token)
+	req.Header.Set("Accept", defaultMediaType)
+	req.Header.Set("Content-Type", defaultMediaType)
 
+	return req, nil
+}
+
+// MeasurementsService represents the subset of the API that deals with AppOptics Measurements
+func (c *Client) MeasurementsService() MeasurementsCommunicator {
+	return c.measurementsService
+}
+
+// SpacesService represents the subset of the API that deals with  Measurements
+func (c *Client) SpacesService() SpacesCommunicator {
+	return c.spacesService
+}
+
+// Error makes ErrorResponse satisfy the error interface and can be used to serialize error responses back to the httpClient
+func (e *ErrorResponse) Error() string {
+	errorData, _ := json.Marshal(e)
+	return string(errorData)
+}
+
+// Do performs the HTTP request on the wire, taking an optional second parameter for containing a response
+func (c *Client) Do(req *http.Request, respData interface{}) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+
+	// error in performing request
+	if err != nil {
+		return resp, err
+	}
+
+	// request response contains an error
+	if err = checkError(resp); err != nil {
+		return resp, err
+	}
+
+	defer resp.Body.Close()
+	if respData != nil {
+		if writer, ok := respData.(io.Writer); ok {
+			_, err := io.Copy(writer, resp.Body)
+			return resp, err
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(respData)
+		}
+	}
+
+	return resp, err
+}
+
+// checkError creates an ErrorResponse from the http.Response.Body
+func checkError(resp *http.Response) error {
+	var errResponse ErrorResponse
+	if resp.StatusCode >= 299 {
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(&errResponse)
+		log.Printf("Error: %+v\n", errResponse)
+		return &errResponse
+	}
 	return nil
+}
+
+func dumpBody(body interface{}) {
+	jsonData, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(string(jsonData))
 }

--- a/legacy_client.go
+++ b/legacy_client.go
@@ -1,0 +1,84 @@
+package appoptics
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type LegacyClient interface {
+	Post(batch *MeasurementsBatch) error
+}
+
+type SimpleClient struct {
+	httpClient *http.Client
+	URL        string
+	Token      string
+}
+
+func NewLegacyClient(url, token string) LegacyClient {
+	return &SimpleClient{
+		URL:   url,
+		Token: token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConnsPerHost: 4,
+				IdleConnTimeout:     30 * time.Second,
+			},
+		},
+	}
+}
+
+// Used for the collector's internal metrics
+func (c *SimpleClient) Post(batch *MeasurementsBatch) error {
+	if c.Token == "" {
+		return errors.New("AppOptics httpClient not authenticated")
+	}
+	return c.post(batch, c.Token)
+}
+
+func (c *SimpleClient) post(batch *MeasurementsBatch, token string) error {
+	json, err := json.Marshal(batch)
+	if err != nil {
+		log.Error("Error marshaling AppOptics measurements", "err", err)
+		return err
+	}
+
+	log.Debug("POSTing measurements to AppOptics", "body", string(json))
+	req, err := http.NewRequest("POST", c.URL, bytes.NewBuffer(json))
+	if err != nil {
+		log.Error("Error POSTing measurements to AppOptics", "err", err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(token, "")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		log.Error("Error reading response to AppOptics measurements request", "err", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Error("Error reading response body from AppOptics", "statusCode", resp.StatusCode, "err", err)
+			return err
+		}
+
+		log.Error("Error POSTing measurements to AppOptics", "statusCode", resp.StatusCode, "respBody", string(body))
+		return ErrBadStatus
+	}
+
+	log.Debug("Finished uploading AppOptics measurements")
+
+	return nil
+}

--- a/measurements.go
+++ b/measurements.go
@@ -1,0 +1,79 @@
+package appoptics
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"time"
+)
+
+// Measurement wraps the corresponding API construct: https://docs.appoptics.com/api/#measurements
+type Measurement struct {
+	Name       string                 `json:"name"`
+	Tags       map[string]string      `json:"tags,omitempty"`
+	Value      interface{}            `json:"value,omitempty"`
+	Count      interface{}            `json:"count,omitempty"`
+	Sum        interface{}            `json:"sum,omitempty"`
+	Min        interface{}            `json:"min,omitempty"`
+	Max        interface{}            `json:"max,omitempty"`
+	Last       interface{}            `json:"last,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// MeasurementsBatch is a collection of Measurements persisted to the API at the same time.
+// It can optionally have tags that are applied to all contained Measurements.
+type MeasurementsBatch struct {
+	// Measurements is the collection of timeseries entries being sent to the server
+	Measurements []Measurement `json:"measurements,omitempty"`
+	// Period is a slice of time measured in seconds, used in service-side aggregation
+	Period int64 `json:"period,omitempty"`
+	// Time is a Unix epoch timestamp used to align a group of Measurements on a time boundary
+	Time int64 `json:"time"`
+	// Tags are key-value identifiers that will be applied to all Measurements in the batch
+	Tags *map[string]string `json:"tags,omitempty"`
+}
+
+// MeasurementsCommunicator defines an interface for communicating with the Measurements portion of the AppOptics API
+type MeasurementsCommunicator interface {
+	Create(*MeasurementsBatch) (*http.Response, error)
+}
+
+// MeasurementsService implements MeasurementsCommunicator
+type MeasurementsService struct {
+	client *Client
+}
+
+func NewMeasurementsBatch(m []Measurement, tags *map[string]string) *MeasurementsBatch {
+	return &MeasurementsBatch{
+		Time:         time.Now().UTC().Unix(),
+		Measurements: m,
+		Tags:         tags,
+	}
+}
+
+// Create persists the given MeasurementCollection to AppOptics
+func (ms *MeasurementsService) Create(batch *MeasurementsBatch) (*http.Response, error) {
+	req, err := ms.client.NewRequest("POST", "measurements", batch)
+
+	if err != nil {
+		log.Println("error creating request:", err)
+		return nil, err
+	}
+	return ms.client.Do(req, nil)
+}
+
+// dumpMeasurements is used for debugging
+func dumpMeasurements(measurements interface{}) {
+	ms := measurements.(MeasurementsBatch)
+	for i, measurement := range ms.Measurements {
+		floatValue, ok := measurement.Value.(float64)
+		if !ok {
+			continue
+		}
+		if math.IsNaN(floatValue) {
+			fmt.Println("Found at index ", i)
+			fmt.Printf("found in '%s'", measurement.Name)
+		}
+	}
+}

--- a/measurements.go
+++ b/measurements.go
@@ -13,6 +13,7 @@ type Measurement struct {
 	Name       string                 `json:"name"`
 	Tags       map[string]string      `json:"tags,omitempty"`
 	Value      interface{}            `json:"value,omitempty"`
+	Time       int64                  `json:"time"`
 	Count      interface{}            `json:"count,omitempty"`
 	Sum        interface{}            `json:"sum,omitempty"`
 	Min        interface{}            `json:"min,omitempty"`

--- a/reporter.go
+++ b/reporter.go
@@ -16,9 +16,9 @@ const (
 )
 
 type Reporter struct {
-	measurementSet *MeasurementSet
-	client         LegacyClient
-	prefix         string
+	measurementSet      *MeasurementSet
+	measurementsService *MeasurementsService
+	prefix              string
 
 	batchChan             chan *MeasurementsBatch
 	measurementSetReports chan *MeasurementSetReport
@@ -26,10 +26,10 @@ type Reporter struct {
 	globalTags map[string]string
 }
 
-func NewReporter(measurementSet *MeasurementSet, client LegacyClient, prefix string) *Reporter {
+func NewReporter(measurementSet *MeasurementSet, ms *MeasurementsService, prefix string) *Reporter {
 	r := &Reporter{
 		measurementSet:        measurementSet,
-		client:                client,
+		measurementsService:   ms,
 		prefix:                prefix,
 		batchChan:             make(chan *MeasurementsBatch, 100),
 		measurementSetReports: make(chan *MeasurementSetReport, 1000),
@@ -58,7 +58,7 @@ func (r *Reporter) postMeasurementBatches() {
 		tryCount := 0
 		for {
 			log.Debug("Uploading librato measurements batch", "time", time.Unix(batch.Time, 0), "numMeasurements", len(batch.Measurements), "globalTags", r.globalTags)
-			err := r.client.Post(batch)
+			_, err := r.measurementsService.Create(batch)
 			if err == nil {
 				break
 			}
@@ -107,6 +107,7 @@ func (r *Reporter) flushReport(report *MeasurementSetReport) {
 		}
 		addMeasurement(m)
 	}
+	// TODO: refactor to use guage methods
 	for key, gauge := range report.Gauges {
 		metricName, tags := parseMeasurementKey(key)
 		m := Measurement{

--- a/reporter.go
+++ b/reporter.go
@@ -17,7 +17,7 @@ const (
 
 type Reporter struct {
 	measurementSet *MeasurementSet
-	client         Client
+	client         LegacyClient
 	prefix         string
 
 	batchChan             chan *MeasurementsBatch
@@ -26,7 +26,7 @@ type Reporter struct {
 	globalTags map[string]string
 }
 
-func NewReporter(measurementSet *MeasurementSet, client Client, prefix string) *Reporter {
+func NewReporter(measurementSet *MeasurementSet, client LegacyClient, prefix string) *Reporter {
 	r := &Reporter{
 		measurementSet:        measurementSet,
 		client:                client,

--- a/spaces.go
+++ b/spaces.go
@@ -1,0 +1,45 @@
+package appoptics
+
+import "net/http"
+
+// SpacesResponse represents the returned data payload from Spaces API's List command (/spaces)
+type SpacesResponse struct {
+	Query  map[string]int `json:"query"`
+	Spaces []*Space       `json:"spaces"`
+}
+
+// Space represents a single AppOptics Space
+type Space struct {
+	// ID is the unique identifier of the Space
+	ID int `json:"id"`
+	// Name is the name of the Space
+	Name string `json:"name"`
+}
+
+type SpacesCommunicator interface {
+	List() ([]*Space, *http.Response, error)
+}
+
+type SpacesService struct {
+	client *Client
+}
+
+// List implements the  Spaces API's List command
+func (s *SpacesService) List() ([]*Space, *http.Response, error) {
+	var spaces []*Space
+	req, err := s.client.NewRequest("GET", "spaces", nil)
+
+	if err != nil {
+		return spaces, nil, err
+	}
+
+	var spacesResponse SpacesResponse
+	resp, err := s.client.Do(req, &spacesResponse)
+
+	if err != nil {
+		return spaces, resp, err
+	}
+
+	spaces = spacesResponse.Spaces
+	return spaces, resp, nil
+}


### PR DESCRIPTION
Fixes #14

## What
* Generalize API request creation, performance, and error handling
* Add `MeasurementsService` to hold the interface for the `Measurements` portion of the REST API
* Add `SpacesService` to hold the interface for the `Spaces` portion of the REST API
* Add `Time` to the existing `Measurement` struct
* Add a constant representing the maximum `Measurements` count in a given payload per the API documentation.

## Why
Needed to elevate client-level concerns to just be on the client and push down other concerns into service objects.

## Caveats
* `LegacyClient` is mostly an artifact of the refactoring itself and will go away very soon in a subsequent commit.
* I'm not 100% yet on the idea of leaving the key data pieces of the `Measurement` struct as `interface{}` because this seems to set us up for a lot of type assertions to little real benefit from what I can tell so far. I readily admit that I could be missing something necessary/obvious though, so I'm leaving it that way for now until I can investigate further.
* This PR gets the client in shape to be used in another project. I'm aware of test coverage gaps and will be working tests into the codebase in a subsequent commit.
  
  