### PR TITLE
Feature/4/native batching

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,7 +174,7 @@ func checkError(resp *http.Response) error {
 	if resp.StatusCode >= 299 {
 		dec := json.NewDecoder(resp.Body)
 		dec.Decode(&errResponse)
-		log.Printf("Error: %+v\n", errResponse)
+		log.Printf("error: %+v\n", errResponse)
 		return &errResponse
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -23,8 +23,10 @@ const (
 
 	// MeasurementPostMaxBatchSize defines the max number of Measurements to send to the API at once
 	MeasurementPostMaxBatchSize = 1000
-	defaultBaseURL              = "https://api.appoptics.com/v1/"
-	defaultMediaType            = "application/json"
+	// DefaultPersistenceErrorLimit sets the number of errors that will be allowed before persistence shuts down
+	DefaultPersistenceErrorLimit = 5
+	defaultBaseURL               = "https://api.appoptics.com/v1/"
+	defaultMediaType             = "application/json"
 )
 
 var (

--- a/client.go
+++ b/client.go
@@ -4,44 +4,81 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"net/url"
 	"regexp"
+
+	"fmt"
+
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"fmt"
 )
 
-const(
+const (
 	MajorVersion = 0
 	MinorVersion = 1
 	PatchVersion = 0
+
+	// MeasurementPostMaxBatchSize defines the max number of Measurements to send to the API at once
+	MeasurementPostMaxBatchSize = 1000
+	defaultBaseURL              = "https://api.appoptics.com/v1/"
+	defaultMediaType            = "application/json"
 )
 
 var (
-	// Version is the current version of this client
+	// Version is the current version of this httpClient
 	Version = fmt.Sprintf("%d.%d.%d", MajorVersion, MinorVersion, PatchVersion)
 
 	regexpIllegalNameChars = regexp.MustCompile("[^A-Za-z0-9.:_-]") // from https://www.AppOptics.com/docs/api/#measurements
 	ErrBadStatus           = errors.New("Received non-OK status from AppOptics POST")
 )
 
-type Client interface {
-	Post(batch *MeasurementsBatch) error
+// ServiceAccessor defines an interface for talking to  via domain-specific service constructs
+type ServiceAccessor interface {
+	// MeasurementsService implements an interface for dealing with  Measurements
+	MeasurementsService() MeasurementsCommunicator
+	// SpacesService implements an interface for dealing with  Spaces
+	SpacesService() SpacesCommunicator
 }
 
-type SimpleClient struct {
+// ErrorResponse represents the response body returned when the API reports an error
+type ErrorResponse struct {
+	// Errors holds the error information from the API
+	Errors interface{} `json:"errors"`
+}
+
+// TODO: add API reference URLs here
+// RequestErrorMessage represents the error schema for request errors
+type RequestErrorMessage map[string][]string
+
+// TODO: add API reference URLs here
+// ParamErrorMessage represents the error schema for param errors
+type ParamErrorMessage []map[string]string
+
+// Client implements ServiceAccessor
+type Client struct {
+	// baseURL is the base endpoint of the remote  service
+	baseURL *url.URL
+	// httpClient is the http.Client singleton used for wire interaction
 	httpClient *http.Client
-	URL        string
-	Token      string
+	// token is the private part of the API credential pair
+	token string
+	// measurementsService embeds the httpClient and implements access to the Measurements API
+	measurementsService MeasurementsCommunicator
+	// spacesService embeds the httpClient and implements access to the Spaces API
+	spacesService SpacesCommunicator
 }
 
-func NewClient(url, token string) Client {
-	return &SimpleClient{
-		URL:   url,
-		Token: token,
+// TODO: make this take an optional URL parameter so it can be used against Librato API
+func NewClient(token string) *Client {
+	baseURL, _ := url.Parse(defaultBaseURL)
+	c := &Client{
+		token:   token,
+		baseURL: baseURL,
 		httpClient: &http.Client{
+
 			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				MaxIdleConnsPerHost: 4,
@@ -49,71 +86,104 @@ func NewClient(url, token string) Client {
 			},
 		},
 	}
+	c.measurementsService = &MeasurementsService{c}
+	c.spacesService = &SpacesService{c}
+
+	return c
 }
 
-type MeasurementsBatch struct {
-	Time         int64             `json:"time"`
-	Period       int64             `json:"period,omitempty"`
-	Tags         map[string]string `json:"tags,omitempty"`
-	Measurements []Measurement     `json:"measurements,omitempty"`
-}
-
-type Measurement struct {
-	Name       string                 `json:"name"`
-	Tags       map[string]string      `json:"tags,omitempty"`
-	Value      interface{}            `json:"value,omitempty"`
-	Count      interface{}            `json:"count,omitempty"`
-	Sum        interface{}            `json:"sum,omitempty"`
-	Min        interface{}            `json:"min,omitempty"`
-	Max        interface{}            `json:"max,omitempty"`
-	Last       interface{}            `json:"last,omitempty"`
-	Attributes map[string]interface{} `json:"attributes,omitempty"`
-}
-
-// Used for the collector's internal metrics
-func (c *SimpleClient) Post(batch *MeasurementsBatch) error {
-	if c.Token == "" {
-		return errors.New("AppOptics client not authenticated")
-	}
-	return c.post(batch, c.Token)
-}
-
-func (c *SimpleClient) post(batch *MeasurementsBatch, token string) error {
-	json, err := json.Marshal(batch)
+// NewRequest standardizes the request being sent
+func (c *Client) NewRequest(method, path string, body interface{}) (*http.Request, error) {
+	rel, err := url.Parse(path)
 	if err != nil {
-		log.Error("Error marshaling AppOptics measurements", "err", err)
-		return err
+		return nil, err
 	}
 
-	log.Debug("POSTing measurements to AppOptics", "body", string(json))
-	req, err := http.NewRequest("POST", c.URL, bytes.NewBuffer(json))
-	if err != nil {
-		log.Error("Error POSTing measurements to AppOptics", "err", err)
-		return err
-	}
+	requestURL := c.baseURL.ResolveReference(rel)
 
-	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(token, "")
+	var buffer io.ReadWriter
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		log.Error("Error reading response to AppOptics measurements request", "err", err)
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Error("Error reading response body from AppOptics", "statusCode", resp.StatusCode, "err", err)
-			return err
+	if body != nil {
+		buffer = &bytes.Buffer{}
+		encodeErr := json.NewEncoder(buffer).Encode(body)
+		if encodeErr != nil {
+			dumpMeasurements(body)
+			return nil, encodeErr
 		}
 
-		log.Error("Error POSTing measurements to AppOptics", "statusCode", resp.StatusCode, "respBody", string(body))
-		return ErrBadStatus
+	}
+	req, err := http.NewRequest(method, requestURL.String(), buffer)
+
+	if err != nil {
+		return nil, err
 	}
 
-	log.Debug("Finished uploading AppOptics measurements")
+	req.SetBasicAuth("token", c.token)
+	req.Header.Set("Accept", defaultMediaType)
+	req.Header.Set("Content-Type", defaultMediaType)
 
+	return req, nil
+}
+
+// MeasurementsService represents the subset of the API that deals with AppOptics Measurements
+func (c *Client) MeasurementsService() MeasurementsCommunicator {
+	return c.measurementsService
+}
+
+// SpacesService represents the subset of the API that deals with  Measurements
+func (c *Client) SpacesService() SpacesCommunicator {
+	return c.spacesService
+}
+
+// Error makes ErrorResponse satisfy the error interface and can be used to serialize error responses back to the httpClient
+func (e *ErrorResponse) Error() string {
+	errorData, _ := json.Marshal(e)
+	return string(errorData)
+}
+
+// Do performs the HTTP request on the wire, taking an optional second parameter for containing a response
+func (c *Client) Do(req *http.Request, respData interface{}) (*http.Response, error) {
+	resp, err := c.httpClient.Do(req)
+
+	// error in performing request
+	if err != nil {
+		return resp, err
+	}
+
+	// request response contains an error
+	if err = checkError(resp); err != nil {
+		return resp, err
+	}
+
+	defer resp.Body.Close()
+	if respData != nil {
+		if writer, ok := respData.(io.Writer); ok {
+			_, err := io.Copy(writer, resp.Body)
+			return resp, err
+		} else {
+			err = json.NewDecoder(resp.Body).Decode(respData)
+		}
+	}
+
+	return resp, err
+}
+
+// checkError creates an ErrorResponse from the http.Response.Body
+func checkError(resp *http.Response) error {
+	var errResponse ErrorResponse
+	if resp.StatusCode >= 299 {
+		dec := json.NewDecoder(resp.Body)
+		dec.Decode(&errResponse)
+		log.Printf("Error: %+v\n", errResponse)
+		return &errResponse
+	}
 	return nil
+}
+
+func dumpBody(body interface{}) {
+	jsonData, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println(string(jsonData))
 }

--- a/client.go
+++ b/client.go
@@ -109,10 +109,8 @@ func (c *Client) NewRequest(method, path string, body interface{}) (*http.Reques
 		buffer = &bytes.Buffer{}
 		encodeErr := json.NewEncoder(buffer).Encode(body)
 		if encodeErr != nil {
-			dumpMeasurements(body)
-			return nil, encodeErr
+			log.Println(encodeErr)
 		}
-
 	}
 	req, err := http.NewRequest(method, requestURL.String(), buffer)
 
@@ -182,10 +180,12 @@ func checkError(resp *http.Response) error {
 	return nil
 }
 
-func dumpBody(body interface{}) {
-	jsonData, err := json.MarshalIndent(body, "", "  ")
-	if err != nil {
-		log.Fatalln(err)
+// dumpResponse is a debugging function which dumps the HTTP response to stdout
+func dumpResponse(resp *http.Response) {
+	buf := new(bytes.Buffer)
+	fmt.Printf("response status: %s\n", resp.Status)
+	if resp.Body != nil {
+		buf.ReadFrom(resp.Body)
+		fmt.Printf("response body: %s\n\n", string(buf.Bytes()))
 	}
-	log.Println(string(jsonData))
 }

--- a/legacy_client.go
+++ b/legacy_client.go
@@ -1,0 +1,84 @@
+package appoptics
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type LegacyClient interface {
+	Post(batch *MeasurementsBatch) error
+}
+
+type SimpleClient struct {
+	httpClient *http.Client
+	URL        string
+	Token      string
+}
+
+func NewLegacyClient(url, token string) LegacyClient {
+	return &SimpleClient{
+		URL:   url,
+		Token: token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConnsPerHost: 4,
+				IdleConnTimeout:     30 * time.Second,
+			},
+		},
+	}
+}
+
+// Used for the collector's internal metrics
+func (c *SimpleClient) Post(batch *MeasurementsBatch) error {
+	if c.Token == "" {
+		return errors.New("AppOptics httpClient not authenticated")
+	}
+	return c.post(batch, c.Token)
+}
+
+func (c *SimpleClient) post(batch *MeasurementsBatch, token string) error {
+	json, err := json.Marshal(batch)
+	if err != nil {
+		log.Error("Error marshaling AppOptics measurements", "err", err)
+		return err
+	}
+
+	log.Debug("POSTing measurements to AppOptics", "body", string(json))
+	req, err := http.NewRequest("POST", c.URL, bytes.NewBuffer(json))
+	if err != nil {
+		log.Error("Error POSTing measurements to AppOptics", "err", err)
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(token, "")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		log.Error("Error reading response to AppOptics measurements request", "err", err)
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Error("Error reading response body from AppOptics", "statusCode", resp.StatusCode, "err", err)
+			return err
+		}
+
+		log.Error("Error POSTing measurements to AppOptics", "statusCode", resp.StatusCode, "respBody", string(body))
+		return ErrBadStatus
+	}
+
+	log.Debug("Finished uploading AppOptics measurements")
+
+	return nil
+}

--- a/measurements.go
+++ b/measurements.go
@@ -3,7 +3,6 @@ package appoptics
 import (
 	"fmt"
 	"log"
-	"math"
 	"net/http"
 )
 
@@ -44,17 +43,14 @@ func (ms *MeasurementsService) Create(batch *MeasurementsBatch) (*http.Response,
 	return ms.client.Do(req, nil)
 }
 
-// dumpMeasurements is used for debugging
-func dumpMeasurements(measurements interface{}) {
-	ms := measurements.(MeasurementsBatch)
-	for i, measurement := range ms.Measurements {
-		floatValue, ok := measurement.Value.(float64)
-		if !ok {
-			continue
-		}
-		if math.IsNaN(floatValue) {
-			fmt.Println("Found at index ", i)
-			fmt.Printf("found in '%s'", measurement.Name)
+// printMeasurements pretty-prints the supplied measurements to stdout
+func printMeasurements(data []Measurement) {
+	for _, measurement := range data {
+		fmt.Printf("\nMetric name: '%s' \n", measurement.Name)
+		fmt.Printf("\t value: %d \n", measurement.Value)
+		fmt.Printf("\t\tTags: ")
+		for k, v := range measurement.Tags {
+			fmt.Printf("\n\t\t\t%s: %s", k, v)
 		}
 	}
 }

--- a/measurements.go
+++ b/measurements.go
@@ -1,0 +1,79 @@
+package appoptics
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"time"
+)
+
+// Measurement wraps the corresponding API construct: https://docs.appoptics.com/api/#measurements
+type Measurement struct {
+	Name       string                 `json:"name"`
+	Tags       map[string]string      `json:"tags,omitempty"`
+	Value      interface{}            `json:"value,omitempty"`
+	Count      interface{}            `json:"count,omitempty"`
+	Sum        interface{}            `json:"sum,omitempty"`
+	Min        interface{}            `json:"min,omitempty"`
+	Max        interface{}            `json:"max,omitempty"`
+	Last       interface{}            `json:"last,omitempty"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// MeasurementsBatch is a collection of Measurements persisted to the API at the same time.
+// It can optionally have tags that are applied to all contained Measurements.
+type MeasurementsBatch struct {
+	// Measurements is the collection of timeseries entries being sent to the server
+	Measurements []Measurement `json:"measurements,omitempty"`
+	// Period is a slice of time measured in seconds, used in service-side aggregation
+	Period int64 `json:"period,omitempty"`
+	// Time is a Unix epoch timestamp used to align a group of Measurements on a time boundary
+	Time int64 `json:"time"`
+	// Tags are key-value identifiers that will be applied to all Measurements in the batch
+	Tags *map[string]string `json:"tags,omitempty"`
+}
+
+// MeasurementsCommunicator defines an interface for communicating with the Measurements portion of the AppOptics API
+type MeasurementsCommunicator interface {
+	Create(*MeasurementsBatch) (*http.Response, error)
+}
+
+// MeasurementsService implements MeasurementsCommunicator
+type MeasurementsService struct {
+	client *Client
+}
+
+func NewMeasurementsBatch(m []Measurement, tags *map[string]string) *MeasurementsBatch {
+	return &MeasurementsBatch{
+		Time:         time.Now().UTC().Unix(),
+		Measurements: m,
+		Tags:         tags,
+	}
+}
+
+// Create persists the given MeasurementCollection to AppOptics
+func (ms *MeasurementsService) Create(batch *MeasurementsBatch) (*http.Response, error) {
+	req, err := ms.client.NewRequest("POST", "measurements", batch)
+
+	if err != nil {
+		log.Println("error creating request:", err)
+		return nil, err
+	}
+	return ms.client.Do(req, nil)
+}
+
+// dumpMeasurements is used for debugging
+func dumpMeasurements(measurements interface{}) {
+	ms := measurements.(MeasurementsBatch)
+	for i, measurement := range ms.Measurements {
+		floatValue, ok := measurement.Value.(float64)
+		if !ok {
+			continue
+		}
+		if math.IsNaN(floatValue) {
+			fmt.Println("Found at index ", i)
+			fmt.Printf("found in '%s'", measurement.Name)
+		}
+	}
+}

--- a/measurements.go
+++ b/measurements.go
@@ -13,6 +13,7 @@ type Measurement struct {
 	Name       string                 `json:"name"`
 	Tags       map[string]string      `json:"tags,omitempty"`
 	Value      interface{}            `json:"value,omitempty"`
+	Time       int64                  `json:"time"`
 	Count      interface{}            `json:"count,omitempty"`
 	Sum        interface{}            `json:"sum,omitempty"`
 	Min        interface{}            `json:"min,omitempty"`

--- a/measurements.go
+++ b/measurements.go
@@ -5,10 +5,11 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"time"
 )
 
 // Measurement wraps the corresponding API construct: https://docs.appoptics.com/api/#measurements
+// Each Measurement represents a single timeseries value for an associated Metric. If AppOptics receives a Measurement
+// with a Name field that doesn't correspond to an existing Metric, a new Metric will be created.
 type Measurement struct {
 	Name       string                 `json:"name"`
 	Tags       map[string]string      `json:"tags,omitempty"`
@@ -22,19 +23,6 @@ type Measurement struct {
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
 }
 
-// MeasurementsBatch is a collection of Measurements persisted to the API at the same time.
-// It can optionally have tags that are applied to all contained Measurements.
-type MeasurementsBatch struct {
-	// Measurements is the collection of timeseries entries being sent to the server
-	Measurements []Measurement `json:"measurements,omitempty"`
-	// Period is a slice of time measured in seconds, used in service-side aggregation
-	Period int64 `json:"period,omitempty"`
-	// Time is a Unix epoch timestamp used to align a group of Measurements on a time boundary
-	Time int64 `json:"time"`
-	// Tags are key-value identifiers that will be applied to all Measurements in the batch
-	Tags *map[string]string `json:"tags,omitempty"`
-}
-
 // MeasurementsCommunicator defines an interface for communicating with the Measurements portion of the AppOptics API
 type MeasurementsCommunicator interface {
 	Create(*MeasurementsBatch) (*http.Response, error)
@@ -43,14 +31,6 @@ type MeasurementsCommunicator interface {
 // MeasurementsService implements MeasurementsCommunicator
 type MeasurementsService struct {
 	client *Client
-}
-
-func NewMeasurementsBatch(m []Measurement, tags *map[string]string) *MeasurementsBatch {
-	return &MeasurementsBatch{
-		Time:         time.Now().UTC().Unix(),
-		Measurements: m,
-		Tags:         tags,
-	}
 }
 
 // Create persists the given MeasurementCollection to AppOptics

--- a/measurements.go
+++ b/measurements.go
@@ -6,6 +6,11 @@ import (
 	"net/http"
 )
 
+const (
+	// AggregationKey is the key in the Measurement attributes used to tell the AppOptics system to aggregate values
+	AggregationKey = "aggregate"
+)
+
 // Measurement wraps the corresponding API construct: https://docs.appoptics.com/api/#measurements
 // Each Measurement represents a single timeseries value for an associated Metric. If AppOptics receives a Measurement
 // with a Name field that doesn't correspond to an existing Metric, a new Metric will be created.
@@ -30,6 +35,15 @@ type MeasurementsCommunicator interface {
 // MeasurementsService implements MeasurementsCommunicator
 type MeasurementsService struct {
 	client *Client
+}
+
+// NewMeasurement returns a Measurement with the given name and an empty attributes map
+func NewMeasurement(name string) Measurement {
+	attrs := make(map[string]interface{})
+	return Measurement{
+		Name:       name,
+		Attributes: attrs,
+	}
 }
 
 // Create persists the given MeasurementCollection to AppOptics

--- a/measurements_batching.go
+++ b/measurements_batching.go
@@ -128,12 +128,14 @@ LOOP:
 				}
 			}
 		case <-bp.stopBatchingChan:
+			fmt.Println("got stop")
 			ticker.Stop()
 			if len(currentMeasurements) > 0 {
 				if len(bp.errors) < bp.errorLimit {
 					bp.batchChan <- &MeasurementsBatch{Measurements: currentMeasurements[:MeasurementPostMaxBatchSize]}
 				}
 			}
+			close(bp.batchChan)
 			bp.stopPersistingChan <- true
 			bp.stopErrorChan <- true
 			break LOOP

--- a/measurements_batching.go
+++ b/measurements_batching.go
@@ -1,0 +1,180 @@
+package appoptics
+
+import (
+	"fmt"
+	"time"
+
+	"bytes"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/solarwinds/prometheus2appoptics/config"
+)
+
+// MeasurementsBatch is a collection of Measurements persisted to the API at the same time.
+// It can optionally have tags that are applied to all contained Measurements.
+type MeasurementsBatch struct {
+	// Measurements is the collection of timeseries entries being sent to the server
+	Measurements []Measurement `json:"measurements,omitempty"`
+	// Period is a slice of time measured in seconds, used in service-side aggregation
+	Period int64 `json:"period,omitempty"`
+	// Time is a Unix epoch timestamp used to align a group of Measurements on a time boundary
+	Time int64 `json:"time"`
+	// Tags are key-value identifiers that will be applied to all Measurements in the batch
+	Tags *map[string]string `json:"tags,omitempty"`
+}
+
+// BatchPersister implements persistence to AppOptics and enforces error limits
+type BatchPersister struct {
+	// ms is the MeasurementsCommunicator used to talk to the AppOptics API
+	ms MeasurementsCommunicator
+	// errorLimit is the number of persistence errors that will be tolerated
+	errorLimit int
+	// prepChan is a channel of Measurements slices
+	prepChan chan []Measurement
+	// batchChan is used to create MeasurementsBatches for persistence to AppOptics
+	batchChan chan *MeasurementsBatch
+	// stopChan is used to cease persisting MeasurementsBatches to AppOptics
+	stopChan chan bool
+	// errorChan is used to tally errors that occur in batching/persisting
+	errorChan chan error
+}
+
+// NewBatchPersister sets up a new instance of batched persistence capabilites using the provided MeasurementsCommunicator
+func NewBatchPersister(ms MeasurementsCommunicator) *BatchPersister {
+	return &BatchPersister{
+		ms:         ms,
+		errorLimit: DefaultPersistenceErrorLimit,
+		prepChan:   make(chan []Measurement),
+		batchChan:  make(chan *MeasurementsBatch),
+		stopChan:   make(chan bool),
+		errorChan:  make(chan error),
+	}
+}
+
+func NewMeasurementsBatch(m []Measurement, tags *map[string]string) *MeasurementsBatch {
+	return &MeasurementsBatch{
+		Measurements: m,
+		Tags:         tags,
+		Time:         time.Now().UTC().Unix(),
+	}
+}
+
+// MeasurementsSink gives calling code write-only access to the Measurements prep channel
+func (bp *BatchPersister) MeasurementsSink() chan<- []Measurement {
+	return bp.prepChan
+}
+
+// MeasurementsStopChannel gives calling code write-only access to the Measurements control channel
+func (bp *BatchPersister) MeasurementsStopChannel() chan<- bool {
+	return bp.stopChan
+}
+
+// MeasurementsErrorChannel gives calling code write-only access to the Measurements error channel
+func (bp *BatchPersister) MeasurementsErrorChannel() chan<- error {
+	return bp.errorChan
+}
+
+// batchMeasurements reads slices of Measurements types off a channel and packages them
+// into batches conforming to the limitations imposed by the API.
+func (bp *BatchPersister) batchMeasurements() {
+	var ms = []Measurement{}
+LOOP:
+	for {
+		select {
+		case mslice := <-bp.prepChan:
+			ms = append(ms, mslice...)
+			if len(ms) >= MeasurementPostMaxBatchSize {
+				pushBatch := &MeasurementsBatch{
+					Measurements: ms[:MeasurementPostMaxBatchSize],
+				}
+				bp.batchChan <- pushBatch
+				ms = ms[MeasurementPostMaxBatchSize:]
+			}
+		case <-bp.stopChan:
+			break LOOP
+		}
+	}
+}
+
+// BatchAndPersistMeasurementsForever continually packages up Measurements from the channel returned by MeasurementSink()
+// and persists them to the AppOptics backend
+func (bp *BatchPersister) BatchAndPersistMeasurementsForever() {
+	go bp.batchMeasurements()
+	go bp.persistBatches()
+	go bp.managePersistenceErrors()
+}
+
+// persistBatches reads maximal slices of AppOptics.Measurement types off a channel and persists them to the remote AppOptics
+// API. Errors are placed on the error channel.
+func (bp *BatchPersister) persistBatches() {
+	ticker := time.NewTicker(time.Millisecond * 500)
+LOOP:
+	for {
+		select {
+		case <-ticker.C:
+			batch := <-bp.batchChan
+			err := bp.persistBatch(batch)
+			if err != nil {
+				bp.errorChan <- err
+			}
+		case <-bp.stopChan:
+			ticker.Stop()
+			break LOOP
+		}
+	}
+}
+
+// managePersistenceErrors tracks errors on the provided channel and sends a stop signal if the ErrorLimit is reached
+func (bp *BatchPersister) managePersistenceErrors() {
+	var errors []error
+LOOP:
+	for {
+		select {
+		case err := <-bp.errorChan:
+			errors = append(errors, err)
+			if len(errors) > bp.errorLimit {
+				bp.stopChan <- true
+				break LOOP
+			}
+		}
+
+	}
+}
+
+// persistBatch sends to the remote AppOptics endpoint unless config.SendStats() returns false, when it prints to stdout
+func (bp *BatchPersister) persistBatch(batch *MeasurementsBatch) error {
+	if config.SendStats() {
+		log.Printf("persisting %d Measurements to AppOptics\n", len(batch.Measurements))
+		resp, err := bp.ms.Create(batch)
+		if resp == nil {
+			fmt.Println("response is nil")
+			return err
+		}
+		dumpResponse(resp)
+	} else {
+		printMeasurements(batch.Measurements)
+	}
+	return nil
+}
+
+// printMeasurements pretty-prints the supplied measurements to stdout
+func printMeasurements(data []Measurement) {
+	for _, measurement := range data {
+		fmt.Printf("\nMetric name: '%s' \n", measurement.Name)
+		fmt.Printf("\t value: %d \n", measurement.Value)
+		fmt.Printf("\t\tTags: ")
+		for k, v := range measurement.Tags {
+			fmt.Printf("\n\t\t\t%s: %s", k, v)
+		}
+	}
+}
+
+func dumpResponse(resp *http.Response) {
+	buf := new(bytes.Buffer)
+	fmt.Printf("response status: %s\n", resp.Status)
+	if resp.Body != nil {
+		buf.ReadFrom(resp.Body)
+		fmt.Printf("response body: %s\n\n", string(buf.Bytes()))
+	}
+}

--- a/measurements_batching.go
+++ b/measurements_batching.go
@@ -128,7 +128,6 @@ LOOP:
 				}
 			}
 		case <-bp.stopBatchingChan:
-			fmt.Println("got stop")
 			ticker.Stop()
 			if len(currentMeasurements) > 0 {
 				if len(bp.errors) < bp.errorLimit {

--- a/measurements_batching.go
+++ b/measurements_batching.go
@@ -121,6 +121,7 @@ LOOP:
 					bp.batchChan <- pushBatch
 					currentMeasurements = currentMeasurements[MeasurementPostMaxBatchSize:]
 				} else {
+					pushBatch.Measurements = currentMeasurements
 					bp.batchChan <- pushBatch
 					currentMeasurements = []Measurement{}
 				}
@@ -206,7 +207,9 @@ func (bp *BatchPersister) persistBatch(batch *MeasurementsBatch) error {
 		// TODO: make this conditional upon log level
 		dumpResponse(resp)
 	} else {
-		printMeasurements(batch.Measurements)
+		// TODO: make this more verbose upon log level
+		log.Printf("received %d Measurements for persistence\n", len(batch.Measurements))
+		//printMeasurements(batch.Measurements)
 	}
 	return nil
 }

--- a/measurements_batching.go
+++ b/measurements_batching.go
@@ -164,9 +164,11 @@ LOOP:
 				}
 			}
 		case <-bp.stopPersistingChan:
-			batch := <-bp.batchChan
-			if batch != nil {
-				bp.persistBatch(batch)
+			if len(bp.errors) > bp.errorLimit {
+				batch := <-bp.batchChan
+				if batch != nil {
+					bp.persistBatch(batch)
+				}
 			}
 			ticker.Stop()
 			break LOOP

--- a/measurements_batching_test.go
+++ b/measurements_batching_test.go
@@ -1,0 +1,73 @@
+package appoptics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBatchPersister(t *testing.T) {
+	mms := &MockMeasurementsService{}
+
+	t.Run("creates maximal batches", func(t *testing.T) {
+		bp := NewBatchPersister(mms, false)
+		batchCount := 2
+		batchCollection := []*MeasurementsBatch{}
+
+		go bp.batchMeasurements()
+
+		go func() {
+			for i := 0; i < (MeasurementPostMaxBatchSize * batchCount); i++ {
+				// MeasurementsSink() is write-only bp.prepChan
+				bp.MeasurementsSink() <- []Measurement{{Value: 3.14, Time: time.Now().UTC().Unix()}}
+			}
+			close(bp.prepChan)
+		}()
+
+		for batch := range bp.batchChan {
+			batchCollection = append(batchCollection, batch)
+			if len(batchCollection) == batchCount {
+				bp.stopBatchingChan <- true
+			}
+		}
+
+		if len(batchCollection) != batchCount {
+			t.Errorf("expected batch count to be %d but was %d", batchCount, len(batchCollection))
+		}
+	})
+
+	t.Run("respects push interval", func(t *testing.T) {
+		bp := NewBatchPersister(mms, false)
+		batchCollection := []*MeasurementsBatch{}
+		measurementsCount := 5
+
+		if measurementsCount > MeasurementPostMaxBatchSize {
+			t.Errorf("measurements count larger than batch size makes no sense in this test")
+		}
+
+		bp.SetMaximumPushInterval(100)
+
+		go bp.batchMeasurements()
+
+		go func() {
+			for i := 0; i < measurementsCount; i++ {
+				// MeasurementsSink() is write-only bp.prepChan
+				bp.MeasurementsSink() <- []Measurement{{Value: 3.14, Time: time.Now().UTC().Unix()}}
+			}
+			close(bp.prepChan)
+		}()
+
+		// grab the single batch that will be on the channel
+		for batch := range bp.batchChan {
+			batchCollection = append(batchCollection, batch)
+			if len(batchCollection[0].Measurements) == measurementsCount {
+				bp.stopBatchingChan <- true
+			}
+		}
+
+		measurementsInBatch := len(batchCollection[0].Measurements)
+
+		if measurementsInBatch != measurementsCount {
+			t.Errorf("expected Measurements in single batch to be %d but was %d", measurementsCount, measurementsInBatch)
+		}
+	})
+}

--- a/mock_measurements_service.go
+++ b/mock_measurements_service.go
@@ -1,0 +1,11 @@
+package appoptics
+
+import "net/http"
+
+type MockMeasurementsService struct {
+	OnCreate func(batch *MeasurementsBatch) (*http.Response, error)
+}
+
+func (m *MockMeasurementsService) Create(batch *MeasurementsBatch) (*http.Response, error) {
+	return m.OnCreate(batch)
+}

--- a/reporter.go
+++ b/reporter.go
@@ -16,9 +16,9 @@ const (
 )
 
 type Reporter struct {
-	measurementSet *MeasurementSet
-	client         LegacyClient
-	prefix         string
+	measurementSet      *MeasurementSet
+	measurementsService *MeasurementsService
+	prefix              string
 
 	batchChan             chan *MeasurementsBatch
 	measurementSetReports chan *MeasurementSetReport
@@ -26,10 +26,10 @@ type Reporter struct {
 	globalTags map[string]string
 }
 
-func NewReporter(measurementSet *MeasurementSet, client LegacyClient, prefix string) *Reporter {
+func NewReporter(measurementSet *MeasurementSet, ms *MeasurementsService, prefix string) *Reporter {
 	r := &Reporter{
 		measurementSet:        measurementSet,
-		client:                client,
+		measurementsService:   ms,
 		prefix:                prefix,
 		batchChan:             make(chan *MeasurementsBatch, 100),
 		measurementSetReports: make(chan *MeasurementSetReport, 1000),
@@ -58,7 +58,7 @@ func (r *Reporter) postMeasurementBatches() {
 		tryCount := 0
 		for {
 			log.Debug("Uploading librato measurements batch", "time", time.Unix(batch.Time, 0), "numMeasurements", len(batch.Measurements), "globalTags", r.globalTags)
-			err := r.client.Post(batch)
+			_, err := r.measurementsService.Create(batch)
 			if err == nil {
 				break
 			}
@@ -107,6 +107,7 @@ func (r *Reporter) flushReport(report *MeasurementSetReport) {
 		}
 		addMeasurement(m)
 	}
+	// TODO: refactor to use guage methods
 	for key, gauge := range report.Gauges {
 		metricName, tags := parseMeasurementKey(key)
 		m := Measurement{

--- a/reporter.go
+++ b/reporter.go
@@ -17,7 +17,7 @@ const (
 
 type Reporter struct {
 	measurementSet *MeasurementSet
-	client         Client
+	client         LegacyClient
 	prefix         string
 
 	batchChan             chan *MeasurementsBatch
@@ -26,7 +26,7 @@ type Reporter struct {
 	globalTags map[string]string
 }
 
-func NewReporter(measurementSet *MeasurementSet, client Client, prefix string) *Reporter {
+func NewReporter(measurementSet *MeasurementSet, client LegacyClient, prefix string) *Reporter {
 	r := &Reporter{
 		measurementSet:        measurementSet,
 		client:                client,

--- a/spaces.go
+++ b/spaces.go
@@ -1,0 +1,45 @@
+package appoptics
+
+import "net/http"
+
+// SpacesResponse represents the returned data payload from Spaces API's List command (/spaces)
+type SpacesResponse struct {
+	Query  map[string]int `json:"query"`
+	Spaces []*Space       `json:"spaces"`
+}
+
+// Space represents a single AppOptics Space
+type Space struct {
+	// ID is the unique identifier of the Space
+	ID int `json:"id"`
+	// Name is the name of the Space
+	Name string `json:"name"`
+}
+
+type SpacesCommunicator interface {
+	List() ([]*Space, *http.Response, error)
+}
+
+type SpacesService struct {
+	client *Client
+}
+
+// List implements the  Spaces API's List command
+func (s *SpacesService) List() ([]*Space, *http.Response, error) {
+	var spaces []*Space
+	req, err := s.client.NewRequest("GET", "spaces", nil)
+
+	if err != nil {
+		return spaces, nil, err
+	}
+
+	var spacesResponse SpacesResponse
+	resp, err := s.client.Do(req, &spacesResponse)
+
+	if err != nil {
+		return spaces, resp, err
+	}
+
+	spaces = spacesResponse.Spaces
+	return spaces, resp, nil
+}


### PR DESCRIPTION
**LAND #15 FIRST!**

## What
Native batching to fully handle the **entity direct creation** use case.

* `BatchPersister` construct handles both size and time-based batching, with defaults corresponding to AppOptics' Measurements API's documentation.
* The code will respect a configurable error limit and shut down persistence if the error limit is reached
* The client exposes write-only versions of its component channels to calling code
* NOTE: this doesn't fully handle the type of batched persistence that `Reporter` represents in the legacy code -- namely because the automatic batching doesn't allow for setting periods and floored time values for server-side aggregation. This will be addressed in a subsequent PR.

## Why
When working on integration projects with this client, it's necessary to allow the user to create arbitrary slices of `Measurement` types and put them on a channel for batching and persistence.